### PR TITLE
Bump to v0.2.1 to fix PyPi release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pylade"
-version = "0.2.0"
+version = "0.2.1"
 description = "PyLaDe - Language Detection tool written in Python."
 authors = ["Pierpaolo Pantone <24alsecondo@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
The old release v0.2.0 needed to be re-uploaded, but PyPi doesn't allow to do so unless the version number changes. So we bump to v0.2.1.