### PR TITLE
Remove support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-    - "3.7"
     - "3.8"
     - "3.9"
     - "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/fievelk/pylade"
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.7 <=3.12"
+python = "^3.8 <=3.12"
 nltk = "^3.8.1"
 
 [tool.poetry.group.dev.dependencies]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 
-envlist = py{37,38,39,310,311}
+envlist = py{38,39,310,311}
 
 [testenv]
 


### PR DESCRIPTION
Python 3.7 is about to reach its End Of Life in about 3 months:
<img width="754" alt="image" src="https://user-images.githubusercontent.com/2814672/226180795-086c5bf5-31b2-46f3-acd2-c37f547db2c8.png">

For this reason, I'm deprecating it. This also fixes some issues with sphinx, that already doesn't support 3.7 anymore.